### PR TITLE
systemBuilder: assign default hostName

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -71,8 +71,10 @@ let
       in
       systemBuilder {
         specialArgs = specialArgs // { inherit ezModules; };
-        modules = [ configModule ]
-          ++ optionals importDefault [ (ezModules.default or { }) ]
+        modules = [
+          configModule
+          { networking.hostName = lib.mkDefault "${name}"; }
+          ] ++ optionals importDefault [ (ezModules.default or { }) ]
           ++ optionals (userHomeModules != [ ]) [
           hmModule
           { home-manager.extraSpecialArgs = extraSpecialArgs // { ezModules = ezHomeModules; }; }


### PR DESCRIPTION
Since the hosts are organized by file and the filename is assumed to correspond to the hostname we can provide that as default value for the
  networking.hostName
option that is valid for both nixosConfigurations as well as darwinConfigurations.