### PR TITLE
`readModules`: recurse into subdirectories

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -172,7 +172,10 @@ let
             { ${removeSuffix ".nix" entry} = "${dir}/${entry}"; }
           else if pathExists dirDefault && readFileType dirDefault == "regular" then
             { ${entry} = dirDefault; }
-          else { }
+          else if type == "directory" then
+            { ${entry} = readModules "${dir}/${entry}"; }
+          else
+            { }
         )
         (readDir dir)
     else { }


### PR DESCRIPTION
Hey. I was wondering if `readModules` should recurse into subdirectories and produce a nested attrSet of modules?

I migrated from a [much more convoluted and deprecated framework](https://github.com/divnix/digga) for organizing the nixos configs to ez-configs and noticed the difference in behavior.

I got used to structuring the modules this way and was wondering if it was a deliberate decision for ez-configs `readModules` to produce a flat set of modules.

For a directory structure
```
├── A
│   └── default.nix
├── B.nix
└── C
    ├── D.nix
    ├── non-nix-file-ignored.txt
    └── E
        ├── default.nix
        ├── some-helper-file-ignored.nix
        └── F
            └── another-helper-file-ignored.nix
```

the current implementation produces an attrSet like this

```
{
  A = "/path/to/A/default.nix";
  B = "/path/to/B.nix";
}
```

while the recursive implementation  proposed in this PR would produce an attrSet like this

```
{
  A = "/path/to/A/default.nix";
  B = "/path/to/B.nix";
  C = {
    D = "/path/to/C/D.nix";
    E = "/path/to/C/E/default.nix";
  };
}
```