### PR TITLE
Add `configurationEntryPoint` option

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -159,14 +159,14 @@ let
       )
       userModules;
 
-  readModules = dir:
+  readModules = { dir, entryPoint ? "default.nix" }:
     if pathExists "${dir}.nix" && readFileType "${dir}.nix" == "regular" then
       { default = dir; }
     else if pathExists dir && readFileType dir == "directory" then
       concatMapAttrs
         (entry: type:
           let
-            dirDefault = "${dir}/${entry}/default.nix";
+            dirDefault = "${dir}/${entry}/${entryPoint}";
           in
           if type == "regular" && hasSuffix ".nix" entry then
             { ${removeSuffix ".nix" entry} = "${dir}/${entry}"; }
@@ -320,6 +320,15 @@ let
       '';
     };
 
+    configurationEntryPoint = mkOption {
+      default = "default.nix";
+      defaultText = literalExpression "\"default.nix\"";
+      type = types.str;
+      description = ''
+        Entry point file for ${configType}Configurations.
+      '';
+    };
+
     earlyModuleArgs = mkOption {
       default = cfg.earlyModuleArgs;
       defaultText = literalExpression "ezConfigs.earlyModuleArgs";
@@ -442,13 +451,13 @@ in
   };
 
   config.flake = rec {
-    homeModules = injectEarly cfg.home.earlyModuleArgs (readModules cfg.home.modulesDirectory);
-    nixosModules = injectEarly cfg.nixos.earlyModuleArgs (readModules cfg.nixos.modulesDirectory);
-    darwinModules = injectEarly cfg.darwin.earlyModuleArgs (readModules cfg.darwin.modulesDirectory);
+    homeModules = injectEarly cfg.home.earlyModuleArgs (readModules { dir = cfg.home.modulesDirectory; });
+    nixosModules = injectEarly cfg.nixos.earlyModuleArgs (readModules { dir = cfg.nixos.modulesDirectory; });
+    darwinModules = injectEarly cfg.darwin.earlyModuleArgs (readModules { dir = cfg.darwin.modulesDirectory; });
 
     homeConfigurations = userConfigs
       {
-        userModules = readModules cfg.home.configurationsDirectory;
+        userModules = readModules { dir=cfg.home.configurationsDirectory; entryPoint=cfg.home.configurationEntryPoint; };
         defaultUser = defaultSubmodule userOptions;
         ezModules = homeModules;
         inherit (cfg.home) extraSpecialArgs;
@@ -458,10 +467,10 @@ in
     nixosConfigurations = systemsWith
       {
         os = "linux";
-        hostModules = readModules cfg.nixos.configurationsDirectory;
+        hostModules = readModules { dir=cfg.nixos.configurationsDirectory; entryPoint=cfg.nixos.configurationEntryPoint; };
         defaultHost = defaultSubmoduleAttr ((configurationOptions "nixos").hosts.type);
         ezModules = nixosModules;
-        userModules = readModules cfg.home.configurationsDirectory;
+        userModules = readModules { dir=cfg.home.configurationsDirectory; entryPoint=cfg.home.configurationEntryPoint; };
         ezHomeModules = homeModules;
         inherit (cfg.nixos) specialArgs;
         inherit (cfg.home) extraSpecialArgs users;
@@ -471,10 +480,10 @@ in
     darwinConfigurations = systemsWith
       {
         os = "darwin";
-        hostModules = readModules cfg.darwin.configurationsDirectory;
+        hostModules = readModules { dir=cfg.darwin.configurationsDirectory; entryPoint=cfg.darwin.configurationEntryPoint; };
         defaultHost = defaultSubmoduleAttr ((configurationOptions "darwin").hosts.type);
         ezModules = darwinModules;
-        userModules = readModules cfg.home.configurationsDirectory;
+        userModules = readModules { dir=cfg.home.configurationsDirectory; entryPoint=cfg.home.configurationEntryPoint; };
         ezHomeModules = homeModules;
         inherit (cfg.darwin) specialArgs;
         inherit (cfg.home) extraSpecialArgs users;


### PR DESCRIPTION
First of all, thanks for this amazing library. Having an opinionated framework for modules organization helped me tame my configuration as it grew.

Still, I had one tooling/usability issue: while refactoring my configuration I often got lost in the multitude of `default.nix` files. Before I migrated to this library I used to have hosts configured in `configuration.nix`, users — in `home.nix`, which gave me a very helpful optical clue. Also, I frankly missed my old directory structure, where all hosts, both darwin and nixos, resided in a single `./hosts` directory.

I made a small change to this lib, which improved usability for me significantly!

My configuration isn't public, but let me illustrate, what kind of configurations are possible with this change:

ezConfigs configuration
```nix
      ezConfigs = {
        root = ./.;
        globalArgs = { inherit inputs; };
        home = {
          configurationsDirectory = ./users;
          configurationEntryPoint = "home.nix";
          modulesDirectory = ./modules/home-manager;
        };
        nixos = {
          configurationsDirectory = ./hosts;
          configurationEntryPoint = "configuration.nix";
          modulesDirectory = ./modules/nixos;
        };
        darwin = {
          configurationsDirectory = ./hosts;
          configurationEntryPoint = "darwin.nix";
          modulesDirectory = ./modules/darwin;
        };
      };
```

Directory structure of my flake (with some nodes omitted for brevity)
```
├── flake.nix
├── hosts
│   ├── iota
│   │   ├── configuration.nix
│   │   └── hardware-configuration.nix
│   └── UA748910
│       └── darwin.nix
├── modules
│   ├── darwin
│   ├── home-manager
│   │   ├── default.nix
│   │   ├── gopass.nix
│   │   ├── home-manager.nix
│   │   ├── mpv.nix
│   │   ├── rofi.nix
│   │   ├── shell-generic.nix
│   │   └── starship.nix
│   └── nixos
│       ├── default.nix
│       └── globaprotect
│           ├── default.nix
│           └── csd.sh
├── overlays
│   └── ansel.nix
└── users
    └── koiuo
        ├── home.nix
        ├── i3.conf
        └── icc
            ├── B133HAN05.A D6500 2.2 M-S XYZLUT+MTX.icc
            └── LG HDR 4K D6500 2.2 M-S XYZLUT+MTX.icc
```

I believe this feature may be useful to others, and I'd love to see it accepted upstream.