### PR TITLE
Allow setting user module names for system hm modules

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,8 +1,8 @@
 { inputs, lib, config, ... }:
 let
 
-  inherit (builtins) pathExists readDir readFileType elemAt;
-  inherit (lib) mkOption types optionals literalExpression mapAttrs concatMapAttrs genAttrs mkIf;
+  inherit (builtins) pathExists readDir readFileType elemAt isList;
+  inherit (lib) mkOption types optionals literalExpression mapAttrs concatMapAttrs genAttrs id;
   inherit (lib.strings) hasSuffix removeSuffix;
   cfg = config.ezConfigs;
 
@@ -33,7 +33,12 @@ let
       (name: configModule:
       let
         hostSettings = hosts.${name} or defaultHost;
-        inherit (hostSettings) importDefault userHomeModules;
+        inherit (hostSettings) importDefault;
+        # Convert a list of strings into an attribute set with identical names and values.
+        userHomeModules =
+          if isList hostSettings.userHomeModules
+          then genAttrs hostSettings.userHomeModules id
+          else hostSettings.userHomeModules;
         hmModule =
           if inputs ? home-manager then
             (
@@ -75,28 +80,30 @@ let
           configModule
           { networking.hostName = lib.mkDefault "${name}"; }
         ] ++ optionals importDefault [ (ezModules.default or { }) ]
-        ++ optionals (userHomeModules != [ ]) [
+        ++ optionals (userHomeModules != { }) [
           hmModule
-          { home-manager.extraSpecialArgs = extraSpecialArgs // { ezModules = ezHomeModules; }; }
           ({ pkgs, ... }: {
-            home-manager.users = genAttrs
-              userHomeModules
-              (user:
-                if userModules ? ${user} then
-                  let
-                    userSettings = users.${user} or (defaultSubmodule userOptions);
-                  in
-                  {
-                    imports = userImports {
-                      inherit (pkgs) stdenv;
-                      inherit (userSettings) importDefault;
-                      inherit user userModules;
-                      ezModules = ezHomeModules;
-                    };
-                  }
-                else
-                  throw ''User ${user} not found inside homeConfigurations directory, but was added to ${name}.userHomeModules''
-              );
+            home-manager = {
+              extraSpecialArgs = extraSpecialArgs // { ezModules = ezHomeModules; };
+              users = mapAttrs
+                (_: user:
+                  if userModules ? ${user} then
+                    let
+                      userSettings = users.${user} or (defaultSubmodule userOptions);
+                    in
+                    {
+                      imports = userImports {
+                        inherit (pkgs) stdenv;
+                        inherit (userSettings) importDefault;
+                        inherit user userModules;
+                        ezModules = ezHomeModules;
+                      };
+                    }
+                  else
+                    throw ''User ${user} not found inside homeConfigurations directory, but was added to ${name}.userHomeModules''
+                )
+                userHomeModules;
+            };
           })
         ];
       })
@@ -230,13 +237,22 @@ let
 
       userHomeModules = mkOption {
         default = [ ];
-        type = types.listOf types.str;
+        type = types.either (types.listOf types.str) (types.attrsOf types.str);
+        example = literalExpression ''
+          { 
+            alice = "alice-minimal";
+            bob = "bob-full";
+          }
+        '';
         description = ''
-          List of users in ''${ezConfigs.hm.usersDirectory},
+          List or attribute set of users in ''${ezConfigs.hm.usersDirectory},
           whose comfigurations to import as home manager ${system}Modules.
+          If it's a list, each user is assumed to have the same name as the homeModule.
+          You can override this by using an attribute set, where the attribute name
+          is the name of the host user, while value is the name of the homeModule.
           They will be put inside `home-manager.''${user}.imports` list for this host.
 
-          When this list is not empty, the `home-manager.extraSpecialArgs` option
+          When this option is set, the `home-manager.extraSpecialArgs` option
           is also set to the one it would recieve in homeManagerConfigurations
           output, and the appropriate homeManager module is imported.
         '';

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698882062,
-        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699963925,
-        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -1,19 +1,19 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
 
     # If you're going to use darwinConfigurations uncomment next two inputs
     # Otherwise you can remove them
-    # nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-23.05-darwin";
+    # nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
     # darwin = {
-    #   url = "github:lnl7/nix-darwin/master";
+    #   url = "github:lnl7/nix-darwin/nix-darwin-24.11";
     #   inputs.nixpkgs.follows = "nixpkgs-darwin";
     # };
 
     # If you're going to use homeConfigurations uncomment next input
     # Otherwise you can remove it
     # home-manager = {
-    #   url = "github:nix-community/home-manager/release-23.05";
+    #   url = "github:nix-community/home-manager/release-24.11";
     #   inputs.nixpkgs.follows = "nixpkgs";
     # };
 

--- a/test-flake/flake.nix
+++ b/test-flake/flake.nix
@@ -1,13 +1,13 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
-    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-23.05-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
     darwin = {
-      url = "github:lnl7/nix-darwin/master";
+      url = "github:lnl7/nix-darwin/nix-darwin-24.11";
       inputs.nixpkgs.follows = "nixpkgs-darwin";
     };
     home-manager = {
-      url = "github:nix-community/home-manager/release-23.05";
+      url = "github:nix-community/home-manager/release-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-parts = {
@@ -15,7 +15,7 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
     ez-configs = {
-      url = "git+file:..";
+      url = "/Users/ellie/Code/ez-configs";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";
@@ -34,6 +34,10 @@
       ezConfigs = {
         root = ./.;
         globalArgs = { inherit inputs; };
+
+        nixos.hosts.example-nixos.userHomeModules = {
+          system-user = "example-user";
+        };
       };
     };
 }

--- a/test-flake/home-configurations/example-user.nix
+++ b/test-flake/home-configurations/example-user.nix
@@ -1,18 +1,26 @@
 # This is the module that will be imported with the `homeManagerConfigurations.example-user@<system>` configuration
 # You can use `ezModules` as a shorthand for accesing your flake's `homeConfigurations`
 { pkgs, ezModules, osConfig, ... }:
+let users = osConfig.users.users;
+in
 {
   imports = [
     ezModules.direnv
   ];
 
-  home = {
-    username = osConfig.users.users.example-user.name or "example-user";
+  home = rec {
+    username =
+      if (users ? system-user) then
+        users.system-user.name else
+        "example-user";
     stateVersion = "22.05";
-    homeDirectory = osConfig.users.users.example-user.home or (
-      if pkgs.stdenv.isDarwin then
-        "/Users/example-user" else
-        "/home/example-user"
-    );
+    homeDirectory =
+      if (users ? system-user) then
+        users.system-user.home else
+        (
+          if pkgs.stdenv.isDarwin then
+            "/Users/${username}" else
+            "/home/${username}"
+        );
   };
 }

--- a/test-flake/nixos-configurations/example-nixos.nix
+++ b/test-flake/nixos-configurations/example-nixos.nix
@@ -1,4 +1,5 @@
 # This is the module that will be imported with the `nixosConfigurations.example-nixos` system
+{ config, ... }:
 {
   fileSystems = {
     "/" = {
@@ -13,10 +14,11 @@
   };
   swapDevices = [{ device = "/dev/vg1/swap"; }];
 
-  users.users.example-user = {
+  users.users.system-user = rec {
+    name = "alice";
     isNormalUser = true;
-    home = "/home/example-user";
-    description = "Example User";
+    home = "/home/${name}";
+    description = "System User";
     extraGroups = [ "wheel" ];
     initialPassword = "password"; # Change this asap obv
   };


### PR DESCRIPTION
Allows setting an attribute set in a form:
```nix
{
  host-user-name = "homeConfigurations-module";
 }
 ```
 to `{nixos,darwin}.hosts.<hostname>.userHomeModules`
Would close #11