### PR TITLE
feat: Pass standalone pkgs in extraSpecialArgs

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -137,7 +137,7 @@ let
             ${user} = homeManagerConfiguration {
               inherit (standalone) pkgs;
               extraSpecialArgs = extraSpecialArgs //
-                { inherit ezModules; } //
+                { inherit ezModules; inherit (standalone) pkgs; } //
                 # We still want to pass in osConfig even when there is none,
                 # so that modules evaluate properly when using that argument
                 (if passInOsConfig then { osConfig = { }; } else { });


### PR DESCRIPTION
I recently started using ez-configs and noticed modules in standalone configs don't actually get passed the `pkgs` argument. This is troublesome to me, as several of my home modules make use of `pkgs` and are supposed to be shared between my standalone and regular configurations.

As a fix, I sourced it from the supplied `standalone.pkgs` and provided it in `extraSpecialArgs` so that it matches non-standalone behavior.